### PR TITLE
update package.json to allow installation via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,14 @@
 {
-  "main": "json"
+  "name": "systemjs-plugin-json",
+  "version": "0.1.0",
+  "main": "json",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/systemjs/plugin-json.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/systemjs/plugin-json/issues"
+  },
+  "homepage": "https://github.com/systemjs/plugin-json"
 }


### PR DESCRIPTION
Make it possible to install the json plugin via npm. The json plugin currently available on npm (`plugin-json`) doesn't work with systemjs-builder, see issue [#145](https://github.com/systemjs/builder/issues/145).
