### PR TITLE
ESM format by default if a transpiler is available

### DIFF
--- a/json.js
+++ b/json.js
@@ -4,6 +4,10 @@
 
 define({
   translate: function(load) {
+    if (this.builder && this.transpiler) {
+      load.metadata.format = 'esm';
+      return 'exp' + 'ort var __useDefault = true; exp' + 'ort default ' + JSON.stringify(JSON.parse(load.source)) + ';';
+    }
     if (this.builder) {
       load.metadata.format = 'cjs';
       return 'module.exports = ' + JSON.stringify(JSON.parse(load.source));


### PR DESCRIPTION
I've added ESM format by default if a transpiler is available as well as it was previously done for plugin text, see https://github.com/systemjs/plugin-text/commit/f333988001637f04447250782b65262b3c6d1861
ESM format of modules is required for building static bundles with `rollup` option, otherwise it cannot be optimized and bundles contains overhead call of `System.registerDynamic`.
