### PR TITLE
Add file extension into the main field.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "systemjs-plugin-json",
   "version": "0.3.0",
-  "main": "json",
+  "main": "json.js",
   "scripts": {
     "test": "serve ."
   },


### PR DESCRIPTION
Should contains the full name of the main script to avoid errors.

Currently if loaded in npkg as https://unpkg.com/systemjs-plugin-json@0.3.0
It redirects to https://unpkg.com/systemjs-plugin-json@0.3.0/json and results in `Cannot find "/json" in systemjs-plugin-json@0.3.0`
After the fix it should redirect to `https://unpkg.com/systemjs-plugin-json@0.3.0/json.js` and load correctly.